### PR TITLE
Validate minimum samples for slope calculation

### DIFF
--- a/gcc/trendline_estimator.go
+++ b/gcc/trendline_estimator.go
@@ -79,6 +79,10 @@ func (e *trendlineEstimator) update(arrivalTime time.Time, interGroupDelay time.
 }
 
 func fitSlope(packets []packetDelay) (float64, bool) {
+	if len(packets) < 2 {
+		return 0, false
+	}
+
 	sumX := 0.0
 	sumY := 0.0
 


### PR DESCRIPTION
#### Description

This PR adds a small guard in fitSlope to handle cases where fewer than two packets are available. This avoids calculating a slope with insufficient data and returns safely instead.
